### PR TITLE
Add random ticker backtests, consolidate options, Closes #128

### DIFF
--- a/bin/run.ml
+++ b/bin/run.ml
@@ -5,7 +5,8 @@ let runtype_target_check ~runtype ~target : unit =
   | Some _ -> (
       match runtype with
       | Options.Runtype.Backtest | Multitest | Montecarlo | MultiMontecarlo
-      | RandomSliceBacktest | MultiRandomSliceBacktest ->
+      | RandomSliceBacktest | MultiRandomSliceBacktest | RandomTickerBacktest
+      | MultiRandomTickerBacktest ->
           ()
       | _ ->
           Eio.traceln "Must be in a backtest if we have a specified target.";

--- a/bin/run.ml
+++ b/bin/run.ml
@@ -31,7 +31,7 @@ let top ~runtype ~preload ~stacktrace ~no_gui ~target ~save_received ~eio_env
   let run_strategy () =
     Eio.Domain_manager.run domain_manager @@ fun () ->
     Eio.Switch.run @@ fun switch ->
-    let context : Backend_intf.Run_context.t =
+    let context : Options.Context.t =
       {
         strategy = Longleaf_strategies.show strategy_arg;
         runtype;
@@ -46,7 +46,7 @@ let top ~runtype ~preload ~stacktrace ~no_gui ~target ~save_received ~eio_env
         save_to_file;
       }
     in
-    Eio.traceln "@[Context: %a@]@." Backend_intf.Run_context.pp context;
+    Eio.traceln "@[Context: %a@]@." Options.Context.pp context;
     let res = Longleaf_strategies.run context strategy_arg in
     Eio.traceln "@[Final response: %f@]@." res;
     ()

--- a/lib/alpaca_backend.ml
+++ b/lib/alpaca_backend.ml
@@ -127,7 +127,8 @@ module Make (Input : BACKEND_INPUT) : S = struct
           match Tiingo.latest symbols with
           | Ok x -> Result.return x
           | Error s ->
-              Eio.traceln "Error %s from Tiingo.latest, trying again after 5 seconds." s;
+              Eio.traceln
+                "Error %s from Tiingo.latest, trying again after 5 seconds." s;
               Ticker.tick ~runtype env 5.0;
               Tiingo.latest symbols
         in

--- a/lib/alpaca_backend.ml
+++ b/lib/alpaca_backend.ml
@@ -12,7 +12,7 @@ module Make (Input : BACKEND_INPUT) : S = struct
   let get_cash = Backend_position.get_cash
   let env = Input.context.eio_env
   let runtype = Input.context.runtype
-  let overnight = Input.options.overnight
+  let overnight = Input.config.overnight
   let save_received = Input.context.save_received
   let received_data = Bars.empty ()
 
@@ -109,7 +109,7 @@ module Make (Input : BACKEND_INPUT) : S = struct
     Piaf.Client.shutdown tiingo_client;
     ()
 
-  let symbols = Input.options.symbols
+  let symbols = Input.config.symbols
   let is_backtest = false
   let get_account = Trading_api.Accounts.get_account
   let last_data_bar = Error "No last data bar in Alpaca backend"
@@ -139,7 +139,7 @@ module Make (Input : BACKEND_INPUT) : S = struct
 
   let place_order state order =
     let ( let* ) = Result.( let* ) in
-    assert (not @@ Input.options.dropout);
+    assert (not @@ Input.config.dropout);
     let* () = Backtesting.place_order state order in
     Trading_api.Orders.create_market_order order
 

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -83,7 +83,7 @@ let make_bars ~(options : Run_options.t) ~(context : Run_context.t) =
       let bars, target = SliceBacktesting.top ~options bars target in
       (bars, Some target)
   | Live | Manual | Paper | Backtest | Multitest | Montecarlo | MultiMontecarlo
-    ->
+  | RandomTickerBacktest | MultiRandomTickerBacktest ->
       (bars, target)
 
 let make_backend_input (options : Run_options.t) (context : Run_context.t) =
@@ -105,6 +105,7 @@ let make (options : Run_options.t) (context : Run_context.t) =
         Eio.traceln "@[create_backend: Creating Alpaca backend@]@.";
         (module Alpaca_backend.Make (Input) : S)
     | Backtest | Multitest | Montecarlo | MultiMontecarlo | RandomSliceBacktest
+    | RandomTickerBacktest | MultiRandomTickerBacktest
     | MultiRandomSliceBacktest ->
         Eio.traceln "@[create_backend: Creating Backtesting backend@]@.";
         (module Backtesting_backend.Make (Input))

--- a/lib/backend.mli
+++ b/lib/backend.mli
@@ -1,8 +1,5 @@
 module type S = Backend_intf.S
 
-val make :
-  Backend_intf.Run_options.t ->
-  Backend_intf.Run_context.t ->
-  (module Backend_intf.S)
+val make : Options.Config.t -> Options.Context.t -> (module Backend_intf.S)
 (** Using only the options and context, create an instantiated backend. This
     backend can then be used to instantiate a strategy for running.*)

--- a/lib/backend.mli
+++ b/lib/backend.mli
@@ -1,5 +1,5 @@
 module type S = Backend_intf.S
 
-val make : Options.Config.t -> Options.Context.t -> (module Backend_intf.S)
+val make : Options.t -> (module Backend_intf.S)
 (** Using only the options and context, create an instantiated backend. This
     backend can then be used to instantiate a strategy for running.*)

--- a/lib/backend_intf.ml
+++ b/lib/backend_intf.ml
@@ -1,9 +1,5 @@
-module Config = Options.Config
-module Context = Options.Context
-
 module type BACKEND_INPUT = sig
-  val config : Config.t
-  val context : Context.t
+  val options : Options.t
 
   val bars : Bars.t
   (** Historical information, ordered with in time order *)

--- a/lib/backend_intf.ml
+++ b/lib/backend_intf.ml
@@ -1,35 +1,9 @@
-module Run_context = struct
-  type t = {
-    strategy : string;
-    runtype : Options.Runtype.t;
-    eio_env : Eio_unix.Stdenv.base; [@opaque]
-    longleaf_env : Environment.t; [@opaque]
-    switch : Eio.Switch.t; [@opaque]
-    preload : Options.Preload.t;
-    target : string option;
-    save_received : bool;
-    nowait_market_open : bool;
-    mutices : Longleaf_mutex.t;
-    save_to_file : bool;
-  }
-  [@@deriving show]
-end
-
-module Run_options = struct
-  type t = {
-    symbols : string list;
-    tick : float;
-    overnight : bool;
-    resume_after_liquidate : bool;
-    indicators_config : Indicators.Config.t;
-    dropout : bool;
-    randomized_backtest_length : int;
-  }
-end
+module Config = Options.Config
+module Context = Options.Context
 
 module type BACKEND_INPUT = sig
-  val options : Run_options.t
-  val context : Run_context.t
+  val config : Config.t
+  val context : Context.t
 
   val bars : Bars.t
   (** Historical information, ordered with in time order *)

--- a/lib/backtesting_backend.ml
+++ b/lib/backtesting_backend.ml
@@ -24,11 +24,11 @@ module Make (Input : BACKEND_INPUT) : S = struct
   let next_market_open _ = None
   let next_market_close _ = Ptime.max
   let env = Input.context.eio_env
-  let symbols = Input.options.symbols
+  let symbols = Input.config.symbols
   let is_backtest = true
   let shutdown () = ()
   let get_cash = Backend_position.get_cash
-  let overnight = Input.options.overnight
+  let overnight = Input.config.overnight
   let save_received = Input.context.save_received
 
   let place_order state (order : Order.t) =

--- a/lib/backtesting_backend.ml
+++ b/lib/backtesting_backend.ml
@@ -21,15 +21,16 @@ module Make (Input : BACKEND_INPUT) : S = struct
       active_orders = [];
     }
 
+  let context = Input.options.context
   let next_market_open _ = None
   let next_market_close _ = Ptime.max
-  let env = Input.context.eio_env
-  let symbols = Input.config.symbols
+  let env = context.eio_env
+  let symbols = Input.options.symbols
   let is_backtest = true
   let shutdown () = ()
   let get_cash = Backend_position.get_cash
-  let overnight = Input.config.overnight
-  let save_received = Input.context.save_received
+  let overnight = Input.options.overnight
+  let save_received = context.save_received
 
   let place_order state (order : Order.t) =
     Eio.traceln "@[%a@]@." Order.pp order;

--- a/lib/options.ml
+++ b/lib/options.ml
@@ -51,3 +51,32 @@ type t = {
   output_file : string option;
 }
 [@@deriving show]
+
+module Context = struct
+  type t = {
+    strategy : string;
+    runtype : Runtype.t;
+    eio_env : Eio_unix.Stdenv.base; [@opaque]
+    longleaf_env : Environment.t; [@opaque]
+    switch : Eio.Switch.t; [@opaque]
+    preload : Preload.t;
+    target : string option;
+    save_received : bool;
+    nowait_market_open : bool;
+    mutices : Longleaf_mutex.t;
+    save_to_file : bool;
+  }
+  [@@deriving show]
+end
+
+module Config = struct
+  type t = {
+    symbols : string list;
+    tick : float;
+    overnight : bool;
+    resume_after_liquidate : bool;
+    indicators_config : Indicators.Config.t;
+    dropout : bool;
+    randomized_backtest_length : int;
+  }
+end

--- a/lib/options.ml
+++ b/lib/options.ml
@@ -9,6 +9,8 @@ module Runtype = struct
     | MultiMontecarlo
     | RandomSliceBacktest
     | MultiRandomSliceBacktest
+    | RandomTickerBacktest
+    | MultiRandomTickerBacktest
       (* Run multiple tests with ranomly generated target data. *)
   [@@deriving show, eq, yojson, variants]
 

--- a/lib/options.ml
+++ b/lib/options.ml
@@ -45,13 +45,6 @@ module Preload = struct
   let conv = Cmdliner.Arg.conv (of_string_res, pp)
 end
 
-type t = {
-  runtype : Runtype.t;
-  preload : Preload.t;
-  output_file : string option;
-}
-[@@deriving show]
-
 module Context = struct
   type t = {
     strategy : string;
@@ -69,14 +62,13 @@ module Context = struct
   [@@deriving show]
 end
 
-module Config = struct
-  type t = {
-    symbols : string list;
-    tick : float;
-    overnight : bool;
-    resume_after_liquidate : bool;
-    indicators_config : Indicators.Config.t;
-    dropout : bool;
-    randomized_backtest_length : int;
-  }
-end
+type t = {
+  symbols : string list;
+  tick : float;
+  overnight : bool;
+  resume_after_liquidate : bool;
+  indicators_config : Indicators.Config.t;
+  dropout : bool;
+  randomized_backtest_length : int;
+  context : Context.t;
+}

--- a/lib/strategy_utils.ml
+++ b/lib/strategy_utils.ml
@@ -10,7 +10,7 @@ module Make (Backend : Backend_intf.S) = struct
          (fun () ->
            match Backend.next_market_open () with
            | None ->
-               Ticker.tick ~runtype Backend.env Input.options.tick;
+               Ticker.tick ~runtype Backend.env Input.config.tick;
                `Continue
            | Some open_time -> (
                let open_time = Ptime.to_float_s open_time in
@@ -54,7 +54,7 @@ module Make (Backend : Backend_intf.S) = struct
            Eio.traceln
              "@[Liquidating because we are within 10 minutes to market \
               close.@]@.";
-           match Input.options.resume_after_liquidate with
+           match Input.config.resume_after_liquidate with
            | false -> `BeginShutdown
            | true ->
                Eio.traceln
@@ -131,11 +131,11 @@ module Make (Backend : Backend_intf.S) = struct
             let* latest = Backend.latest_bars Backend.symbols in
             let* time = Bars.Latest.timestamp latest in
             Eio.traceln "@[Tick time: %a@]@." Time.pp time;
-            Indicators.add_latest Input.options.indicators_config time
-              state.bars latest state.indicators;
+            Indicators.add_latest Input.config.indicators_config time state.bars
+              latest state.indicators;
             let value = Backend.Backend_position.value latest in
             let risk_free_value =
-              Stats.risk_free_value state.stats Input.options.tick
+              Stats.risk_free_value state.stats Input.config.tick
             in
             Bars.append latest state.bars;
             Result.return

--- a/lib/ticker.ml
+++ b/lib/ticker.ml
@@ -1,6 +1,7 @@
 let tick ~(runtype : Options.Runtype.t) env time =
   match runtype with
   | Backtest | Multitest | Manual | Montecarlo | MultiMontecarlo
-  | RandomSliceBacktest | MultiRandomSliceBacktest ->
+  | RandomSliceBacktest | MultiRandomSliceBacktest | RandomTickerBacktest
+  | MultiRandomTickerBacktest ->
       ()
   | Live | Paper -> Eio.Time.sleep env#clock time

--- a/lib/tiingo_api.ml
+++ b/lib/tiingo_api.ml
@@ -4,7 +4,7 @@ module Hashtbl = Bars.Hashtbl
 type item = {
   ticker : string;
   timestamp : Time.t;
-  last : float [@key "tngoLast"];
+  last : float; [@key "tngoLast"]
   open_ : float; [@key "open"]
   prevClose : float;
   high : float;

--- a/strategies/buy_low_bollinger.ml
+++ b/strategies/buy_low_bollinger.ml
@@ -191,7 +191,7 @@ module BuyLowBollinger (Backend : Backend.S) : Strategy.S = struct
     in
     (* Eio.traceln "%a" (List.pp Float.pp) (List.map snd possibilities); *)
     let random_drop =
-      match Backend.Input.options.dropout with
+      match Backend.Input.config.dropout with
       | true ->
           (* Eio.traceln "buylow: %d possibilities, selecting one randomly" *)
           (* (List.length possibilities); *)

--- a/strategies/buy_low_bollinger.ml
+++ b/strategies/buy_low_bollinger.ml
@@ -191,7 +191,7 @@ module BuyLowBollinger (Backend : Backend.S) : Strategy.S = struct
     in
     (* Eio.traceln "%a" (List.pp Float.pp) (List.map snd possibilities); *)
     let random_drop =
-      match Backend.Input.config.dropout with
+      match Backend.Input.options.dropout with
       | true ->
           (* Eio.traceln "buylow: %d possibilities, selecting one randomly" *)
           (* (List.length possibilities); *)

--- a/strategies/crossover.ml
+++ b/strategies/crossover.ml
@@ -38,7 +38,7 @@ module Buy_inp : Template.Buy_trigger.INPUT = struct
     let* prev = i.previous in
     let conditions =
       [
-        (match i.relative_strength_index >=. 40.0 with
+        (match i.relative_strength_index <=. 40.0 with
         | true -> F.Pass [ "Small RSI" ]
         | false -> Fail [ "RSI too large to buy" ]);
         (* confirmed_crossover state symbol; *)

--- a/strategies/longleaf_strategies.ml
+++ b/strategies/longleaf_strategies.ml
@@ -13,7 +13,8 @@ let run_options : Run_options.t =
     randomized_backtest_length = 1000;
   }
 
-let run_generic (module Strat : Strategy.BUILDER) context =
+let run_generic ?(run_options = run_options) (module Strat : Strategy.BUILDER)
+    context =
   Eio.traceln "@[Starting Doubletop@]@.";
   let module Backend = (val Backend.make run_options context) in
   let module S = Strat (Backend) in
@@ -77,9 +78,11 @@ type multitest = { mean : float; min : float; max : float; std : float }
 
 let run (context : Run_context.t) strategy =
   match context.runtype with
-  | Live | Paper | Backtest | Manual | Montecarlo | RandomSliceBacktest ->
+  | Live | Paper | Backtest | Manual | Montecarlo | RandomSliceBacktest
+  | RandomTickerBacktest ->
       run_strat context strategy
-  | Multitest | MultiMontecarlo | MultiRandomSliceBacktest ->
+  | Multitest | MultiMontecarlo | MultiRandomSliceBacktest
+  | MultiRandomTickerBacktest ->
       let init = Array.make 30 () in
       let res = Array.map (fun _ -> run_strat context strategy) init in
       Array.sort Float.compare res;

--- a/strategies/longleaf_strategies.ml
+++ b/strategies/longleaf_strategies.ml
@@ -1,9 +1,19 @@
 module Context = Options.Context
 module Collections = Ticker_collections
 
-let run_options context : Options.t =
+let run_options (context : Context.t) : Options.t =
+  let symbols =
+    match context.runtype with
+    | RandomTickerBacktest | MultiRandomTickerBacktest ->
+        let arr = Array.of_list Collections.sp100 in
+        let eighty_percent =
+          (Array.length arr |> Float.of_int) *. 0.8 |> Int.of_float
+        in
+        Owl_stats.choose arr eighty_percent |> Array.to_list
+    | _ -> Collections.sp100
+  in
   {
-    symbols = Collections.sp100;
+    symbols;
     tick = 600.0;
     overnight = true;
     resume_after_liquidate = true;

--- a/strategies/longleaf_strategies.ml
+++ b/strategies/longleaf_strategies.ml
@@ -1,8 +1,7 @@
 module Context = Options.Context
-module Config = Options.Config
 module Collections = Ticker_collections
 
-let run_config : Config.t =
+let run_options context : Options.t =
   {
     symbols = Collections.sp100;
     tick = 600.0;
@@ -11,11 +10,13 @@ let run_config : Config.t =
     indicators_config : Indicators.Config.t = { fft = false };
     dropout = false;
     randomized_backtest_length = 1000;
+    context;
   }
 
 let run_generic (module Strat : Strategy.BUILDER) context =
   Eio.traceln "@[Starting Doubletop@]@.";
-  let module Backend = (val Backend.make run_config context) in
+  let options = run_options context in
+  let module Backend = (val Backend.make options) in
   let module S = Strat (Backend) in
   Eio.traceln "Applied strategy functor to backend, running.";
   let res = S.run () in


### PR DESCRIPTION
By default, RandomTickerBacktest will select 80% of the configured symbols to trade on